### PR TITLE
Ignore conflicts when updating user information.

### DIFF
--- a/lib/express-user-role-router.js
+++ b/lib/express-user-role-router.js
@@ -152,6 +152,13 @@ class ExpressUserRoleRouter {
                         context.acl,
                         err => err ? reject(err) : resolve()
                     );
+                }).catch(err => {
+                    // This code is tried on every request, so we can assume that the
+                    // user info will be successfully updated at some point and ignore conflicts here.
+                    if (err.status === 409) {
+                        return;
+                    }
+                    throw err;
                 });
             }
         }).then(next, next);


### PR DESCRIPTION
The _findRole code is ran on every request, so we can assume that
the information will be successfully updated at some point.